### PR TITLE
Adds validations per spec.

### DIFF
--- a/app/models/movie.rb
+++ b/app/models/movie.rb
@@ -1,7 +1,9 @@
 class Movie < ApplicationRecord
-  validates_presence_of :title
-  validates_presence_of :format
-  validates_presence_of :length
-  validates_presence_of :release_year
-  validates_presence_of :rating
+  validates_length_of :title, in: 1..50
+  validates_inclusion_of :format, in: ['VHS', 'DVD', 'Streaming']
+
+  validates_numericality_of :length, less_than: 501, greater_than: -1
+  validates_numericality_of :release_year, less_than: 2101, greater_than: 1799
+  validates_numericality_of :rating, less_than: 6, greater_than: -1
+
 end

--- a/spec/models/movies_spec.rb
+++ b/spec/models/movies_spec.rb
@@ -1,11 +1,19 @@
 require 'rails_helper'
 RSpec.describe Movie, type: :model do
+  before :each do
+    batman = Movie.create(title: "Batman", format: "DVD", length: 150, release_year: 1997, rating: 5)
+  end
+
   describe 'validations' do
-    it { should validate_presence_of(:title)}
-    it { should validate_presence_of(:format)}
-    it { should validate_presence_of(:length)}
-    it { should validate_presence_of(:release_year)}
-    it { should validate_presence_of(:rating)}
+    it { should validate_length_of(:title).is_at_least(1).is_at_most(50)}
+    it { should validate_inclusion_of(:format).in_array(['VHS', 'DVD', 'Streaming'])}
+
+    it { should validate_numericality_of(:length).is_greater_than(-1)}
+    it { should validate_numericality_of(:length).is_less_than(501)}
+    it { should validate_numericality_of(:release_year).is_greater_than(1799)}
+    it { should validate_numericality_of(:release_year).is_less_than(2101)}
+    it { should validate_numericality_of(:rating).is_greater_than(-1)}
+    it { should validate_numericality_of(:rating).is_less_than(6)}
   end
 end
 # a. Title [text; length between 1 and 50 characters]


### PR DESCRIPTION
Movie
  validations
    is expected to validate that :release_year looks like a number less than 2101
    is expected to validate that :format is either ‹"VHS"›, ‹"DVD"›, or ‹"Streaming"›
    is expected to validate that the length of :title is between 1 and 50
    is expected to validate that :length looks like a number less than 501
    is expected to validate that :release_year looks like a number greater than 1799
    is expected to validate that :rating looks like a number less than 6
    is expected to validate that :rating looks like a number greater than -1
    is expected to validate that :length looks like a number greater than -1

